### PR TITLE
feed: add a link per item

### DIFF
--- a/changelog/feeds.go
+++ b/changelog/feeds.go
@@ -32,7 +32,7 @@ func ToFeed(link string, entries []Entry) (*feeds.Feed, error) {
 	for i, e := range entries {
 		feed.Items[i] = &feeds.Item{
 			Created:     e.Date,
-			Link:        &feeds.Link{Href: ""},
+			Link:        &feeds.Link{Href: fmt.Sprintf("%s/ChangeLog.txt#src=feeds&time=%d", link, e.Date.Unix())},
 			Description: e.ToChangeLog(),
 		}
 


### PR DESCRIPTION
despite all the links being the same, and not being able to have an anchor to a place in the ChangeLog.txt, I added a couple of query parameters, so it would be distinct in the access logs, where the links came from and the epoch of the update pointed to.

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>